### PR TITLE
Fix protocol detection regexp

### DIFF
--- a/denops/@dpp-protocols/git.ts
+++ b/denops/@dpp-protocols/git.ts
@@ -93,7 +93,7 @@ export class Protocol extends BaseProtocol<Params> {
 
     const sshMatch = args.plugin.repo.match(/^git@(?<host>[^:]+):(?<name>.+)/);
     const protocolMatch = args.plugin.repo.match(
-      /^(?<protocol>[^:]+):(?<host>[^\/]+)\/(?<name>.+)/,
+      /^(?<protocol>[^:]+):\/\/(?<host>[^\/]+)\/(?<name>.+)/,
     );
     if (sshMatch && sshMatch.groups) {
       // Parse "git@host:name" pattern


### PR DESCRIPTION
`"https://github.com/Shougo/dpp-protocol-git".match(/^(?<protocol>[^:]+):(?<host>[^\/]+)\/(?<name>.+)/)` fails because `//` pattern is missing.
This adds it.