### PR TITLE
fixed: Removed because it generated extra arguments.

### DIFF
--- a/denops/@dpp-protocols/git.ts
+++ b/denops/@dpp-protocols/git.ts
@@ -208,10 +208,6 @@ export class Protocol extends BaseProtocol<Params> {
         commandArgs.push("--filter=blob:none");
       }
 
-      if (args.protocolParams.enablePartialClone) {
-        commandArgs.push("--filter=blob:none");
-      }
-
       if (depth && depth > 0) {
         commandArgs.push(`--depth=${depth}`);
 


### PR DESCRIPTION
The same argument was being input consecutively, so I deleted one of them.

If enablePartialClone was set to true without this modification,
the plugin could not be installed with the error message `fatal: remote error: filter 'combine' not supported`.

However, once this PR is merged, this error will be resolved.